### PR TITLE
BrowserStack and HTTP enhancements

### DIFF
--- a/DFC.TestAutomation.UI/Extension/ScenarioContextExtension.cs
+++ b/DFC.TestAutomation.UI/Extension/ScenarioContextExtension.cs
@@ -101,25 +101,5 @@ namespace DFC.TestAutomation.UI.Extension
         {
             context?.Set(helperLibrary);
         }
-
-        /// <summary>
-        /// Gets the custom set exception.
-        /// </summary>
-        /// <param name="context">Scenario context.</param>
-        /// <returns>A stored instance of the custom exception.</returns>
-        public static Exception GetCustomException(this ScenarioContext context)
-        {
-            return context?.Get<Exception>();
-        }
-
-        /// <summary>
-        /// Sets the helper library.
-        /// </summary>
-        /// <param name="context">Scenario context.</param>
-        /// <param name="exception">The custom exception.</param>
-        public static void SetCustomException(this ScenarioContext context, Exception exception)
-        {
-            context?.Set(exception);
-        }
     }
 }

--- a/DFC.TestAutomation.UI/Extension/ScenarioContextExtension.cs
+++ b/DFC.TestAutomation.UI/Extension/ScenarioContextExtension.cs
@@ -117,7 +117,7 @@ namespace DFC.TestAutomation.UI.Extension
         /// </summary>
         /// <param name="context">Scenario context.</param>
         /// <param name="exception">The custom exception.</param>
-        public static void GetCustomException(this ScenarioContext context, Exception exception)
+        public static void SetCustomException(this ScenarioContext context, Exception exception)
         {
             context?.Set(exception);
         }

--- a/DFC.TestAutomation.UI/Extension/ScenarioContextExtension.cs
+++ b/DFC.TestAutomation.UI/Extension/ScenarioContextExtension.cs
@@ -6,6 +6,7 @@
 using DFC.TestAutomation.UI.Helper;
 using DFC.TestAutomation.UI.Settings;
 using OpenQA.Selenium;
+using System;
 using TechTalk.SpecFlow;
 
 namespace DFC.TestAutomation.UI.Extension
@@ -99,6 +100,26 @@ namespace DFC.TestAutomation.UI.Extension
             where T : IAppSettings
         {
             context?.Set(helperLibrary);
+        }
+
+        /// <summary>
+        /// Gets the custom set exception.
+        /// </summary>
+        /// <param name="context">Scenario context.</param>
+        /// <returns>A stored instance of the custom exception.</returns>
+        public static Exception GetCustomException(this ScenarioContext context)
+        {
+            return context?.Get<Exception>();
+        }
+
+        /// <summary>
+        /// Sets the helper library.
+        /// </summary>
+        /// <param name="context">Scenario context.</param>
+        /// <param name="exception">The custom exception.</param>
+        public static void GetCustomException(this ScenarioContext context, Exception exception)
+        {
+            context?.Set(exception);
         }
     }
 }

--- a/DFC.TestAutomation.UI/Helper/BrowserStackHelper.cs
+++ b/DFC.TestAutomation.UI/Helper/BrowserStackHelper.cs
@@ -99,7 +99,7 @@ namespace DFC.TestAutomation.UI.Helper
             using (var requestSupport = new HttpRequestSupport<BrowserStackTestStatus>(
                 new NetworkCredential(this.BrowserStackSettings.Username, this.BrowserStackSettings.AccessKey),
                 HttpMethod.Put,
-                new Uri($"https://www.browserstack.com/automate/sessions/{webDriverSessionId}.json"),
+                new Uri($"https://api.browserstack.com/automate/sessions/{webDriverSessionId}.json"),
                 new BrowserStackTestStatus() { Status = "failed", Reason = reason }))
             {
                 await requestSupport.Execute().ConfigureAwait(false);

--- a/DFC.TestAutomation.UI/Helper/BrowserStackHelper.cs
+++ b/DFC.TestAutomation.UI/Helper/BrowserStackHelper.cs
@@ -96,17 +96,11 @@ namespace DFC.TestAutomation.UI.Helper
         /// <returns>A task providing information on the asynchronous operation.</returns>
         public async Task SetTestToFailedWithReason(string webDriverSessionId, string reason)
         {
-            var headers = new List<KeyValuePair<string, string>>
-            {
-                new KeyValuePair<string, string>("Content-Type", "application/json"),
-            };
-
             using (var requestSupport = new HttpRequestSupport<BrowserStackTestStatus>(
                 new NetworkCredential(this.BrowserStackSettings.Username, this.BrowserStackSettings.AccessKey),
                 HttpMethod.Put,
                 new Uri($"https://www.browserstack.com/automate/sessions/{webDriverSessionId}.json"),
-                new BrowserStackTestStatus() { Status = "failed", Reason = reason },
-                headers))
+                new BrowserStackTestStatus() { Status = "failed", Reason = reason }))
             {
                 await requestSupport.Execute().ConfigureAwait(false);
             }

--- a/DFC.TestAutomation.UI/Helper/BrowserStackHelper.cs
+++ b/DFC.TestAutomation.UI/Helper/BrowserStackHelper.cs
@@ -94,7 +94,7 @@ namespace DFC.TestAutomation.UI.Helper
         /// <param name="webDriverSessionId">The remote webdriver session id.</param>
         /// <param name="reason">The reason for the test failure.</param>
         /// <returns>A task providing information on the asynchronous operation.</returns>
-        public async Task SetTestToFailedWithReason(string webDriverSessionId, string reason)
+        public async Task<HttpResponseMessage> SetTestToFailedWithReason(string webDriverSessionId, string reason)
         {
             using (var requestSupport = new HttpRequestSupport<BrowserStackTestStatus>(
                 new NetworkCredential(this.BrowserStackSettings.Username, this.BrowserStackSettings.AccessKey),
@@ -102,7 +102,7 @@ namespace DFC.TestAutomation.UI.Helper
                 new Uri($"https://api.browserstack.com/automate/sessions/{webDriverSessionId}.json"),
                 new BrowserStackTestStatus() { Status = "failed", Reason = reason }))
             {
-                await requestSupport.Execute().ConfigureAwait(false);
+                return await requestSupport.Execute().ConfigureAwait(false);
             }
         }
 

--- a/DFC.TestAutomation.UI/Helper/BrowserStackHelper.cs
+++ b/DFC.TestAutomation.UI/Helper/BrowserStackHelper.cs
@@ -106,6 +106,23 @@ namespace DFC.TestAutomation.UI.Helper
             }
         }
 
+        /// <summary>
+        /// Sets the current test to passed.
+        /// </summary>
+        /// <param name="webDriverSessionId">The remote webdriver session id.</param>
+        /// <returns>A task providing information on the asynchronous operation.</returns>
+        public async Task<HttpResponseMessage> SetTestToPassed(string webDriverSessionId)
+        {
+            using (var requestSupport = new HttpRequestSupport<BrowserStackTestStatus>(
+                new NetworkCredential(this.BrowserStackSettings.Username, this.BrowserStackSettings.AccessKey),
+                HttpMethod.Put,
+                new Uri($"https://api.browserstack.com/automate/sessions/{webDriverSessionId}.json"),
+                new BrowserStackTestStatus() { Status = "passed", Reason = string.Empty }))
+            {
+                return await requestSupport.Execute().ConfigureAwait(false);
+            }
+        }
+
         private DriverOptions GetDriverOptions()
         {
             switch (this.BrowserStackSettings.BrowserName.ToLower(CultureInfo.CurrentCulture))

--- a/DFC.TestAutomation.UI/Helper/IBrowserStackHelper.cs
+++ b/DFC.TestAutomation.UI/Helper/IBrowserStackHelper.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 using OpenQA.Selenium;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace DFC.TestAutomation.UI.Helper
 {
@@ -17,5 +19,20 @@ namespace DFC.TestAutomation.UI.Helper
         /// </summary>
         /// <returns>The Selenium remote webdriver.</returns>
         IWebDriver CreateRemoteWebDriver();
+
+        /// <summary>
+        /// Sets the current test to failed.
+        /// </summary>
+        /// <param name="webDriverSessionId">The remote webdriver session id.</param>
+        /// <param name="reason">The reason for the test failure.</param>
+        /// <returns>A task providing information on the asynchronous operation.</returns>
+        Task<HttpResponseMessage> SetTestToFailedWithReason(string webDriverSessionId, string reason);
+
+        /// <summary>
+        /// Sets the current test to passed.
+        /// </summary>
+        /// <param name="webDriverSessionId">The remote webdriver session id.</param>
+        /// <returns>A task providing information on the asynchronous operation.</returns>
+        Task<HttpResponseMessage> SetTestToPassed(string webDriverSessionId);
     }
 }

--- a/DFC.TestAutomation.UI/Model/BrowserStackTestStatus.cs
+++ b/DFC.TestAutomation.UI/Model/BrowserStackTestStatus.cs
@@ -1,9 +1,13 @@
-﻿namespace DFC.TestAutomation.UI.Model
+﻿using Newtonsoft.Json;
+
+namespace DFC.TestAutomation.UI.Model
 {
     internal class BrowserStackTestStatus
     {
+        [JsonProperty("status")]
         public string Status { get; set; }
 
+        [JsonProperty("reason")]
         public string Reason { get; set; }
     }
 }

--- a/DFC.TestAutomation.UI/Model/BrowserStackTestStatus.cs
+++ b/DFC.TestAutomation.UI/Model/BrowserStackTestStatus.cs
@@ -1,0 +1,9 @@
+﻿namespace DFC.TestAutomation.UI.Model
+{
+    internal class BrowserStackTestStatus
+    {
+        public string Status { get; set; }
+
+        public string Reason { get; set; }
+    }
+}

--- a/DFC.TestAutomation.UI/Support/HttpRequestSupport.cs
+++ b/DFC.TestAutomation.UI/Support/HttpRequestSupport.cs
@@ -52,8 +52,8 @@ namespace DFC.TestAutomation.UI.Support
         public HttpRequestSupport(HttpMethod httpMethod, Uri requestUrl, T content)
         {
             this.Client = new HttpClient();
-            var messageContent = GetHttpContentFromObject(content);
-            this.RequestMessage = CreateRequestMessage(httpMethod, requestUrl, messageContent);
+            this.CreateHttpMessageContentFromObject(content);
+            this.CreateHttpRequestMessage(httpMethod, requestUrl, this.MessageContent);
         }
 
         /// <summary>
@@ -66,8 +66,8 @@ namespace DFC.TestAutomation.UI.Support
         public HttpRequestSupport(NetworkCredential networkCredentials, HttpMethod httpMethod, Uri requestUrl, T content)
         {
             this.Client = new HttpClient();
-            var messageContent = GetHttpContentFromObject(content);
-            this.RequestMessage = CreateRequestMessage(httpMethod, requestUrl, messageContent);
+            this.CreateHttpMessageContentFromObject(content);
+            this.CreateHttpRequestMessage(httpMethod, requestUrl, this.MessageContent);
             this.AddNetworkCredentials(networkCredentials);
         }
 
@@ -81,8 +81,8 @@ namespace DFC.TestAutomation.UI.Support
         public HttpRequestSupport(HttpMethod httpMethod, Uri requestUrl, T content, IEnumerable<KeyValuePair<string, string>> headers)
         {
             this.Client = new HttpClient();
-            var messageContent = GetHttpContentFromObject(content);
-            this.RequestMessage = CreateRequestMessage(httpMethod, requestUrl, messageContent);
+            this.CreateHttpMessageContentFromObject(content);
+            this.CreateHttpRequestMessage(httpMethod, requestUrl, this.MessageContent);
 
             if (headers != null)
             {
@@ -104,8 +104,8 @@ namespace DFC.TestAutomation.UI.Support
         public HttpRequestSupport(NetworkCredential networkCredentials, HttpMethod httpMethod, Uri requestUrl, T content, IEnumerable<KeyValuePair<string, string>> headers)
         {
             this.Client = new HttpClient();
-            var messageContent = GetHttpContentFromObject(content);
-            this.RequestMessage = CreateRequestMessage(httpMethod, requestUrl, messageContent);
+            this.CreateHttpMessageContentFromObject(content);
+            this.CreateHttpRequestMessage(httpMethod, requestUrl, this.MessageContent);
 
             if (headers != null)
             {
@@ -123,6 +123,8 @@ namespace DFC.TestAutomation.UI.Support
         private HttpClient Client { get; set; }
 
         private HttpRequestMessage RequestMessage { get; set; }
+
+        private ByteArrayContent MessageContent { get; set; }
 
         /// <inheritdoc/>
         public void Dispose()
@@ -164,23 +166,19 @@ namespace DFC.TestAutomation.UI.Support
             return new HttpRequestMessage(httpMethod, requestUrl);
         }
 
-        private static HttpRequestMessage CreateRequestMessage(HttpMethod httpMethod, Uri requestUrl, HttpContent httpContent)
+        private void CreateHttpRequestMessage(HttpMethod httpMethod, Uri requestUrl, HttpContent httpContent)
         {
             var requestMessage = CreateRequestMessage(httpMethod, requestUrl);
             requestMessage.Content = httpContent;
-            return requestMessage;
+            this.RequestMessage = requestMessage;
         }
 
-        private static HttpContent GetHttpContentFromObject(T content)
+        private void CreateHttpMessageContentFromObject(T content)
         {
             var jsonContent = JsonConvert.SerializeObject(content);
             var byteContent = Encoding.UTF8.GetBytes(jsonContent);
-
-            using (var messageContent = new ByteArrayContent(byteContent))
-            {
-                messageContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-                return messageContent;
-            }
+            this.MessageContent = new ByteArrayContent(byteContent);
+            this.MessageContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
         }
 
         private void AddNetworkCredentials(NetworkCredential networkCredential)

--- a/DFC.TestAutomation.UI/Support/HttpRequestSupport.cs
+++ b/DFC.TestAutomation.UI/Support/HttpRequestSupport.cs
@@ -6,6 +6,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -32,6 +33,19 @@ namespace DFC.TestAutomation.UI.Support
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpRequestSupport{T}"/> class.
         /// </summary>
+        /// <param name="networkCredentials">The network credentials.</param>
+        /// <param name="httpMethod">The HTTP method.</param>
+        /// <param name="requestUrl">The HTTP request url.</param>
+        public HttpRequestSupport(NetworkCredential networkCredentials, HttpMethod httpMethod, Uri requestUrl)
+        {
+            this.Client = new HttpClient();
+            this.RequestMessage = CreateRequestMessage(httpMethod, requestUrl);
+            this.AddNetworkCredentials(networkCredentials);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestSupport{T}"/> class.
+        /// </summary>
         /// <param name="httpMethod">The HTTP method.</param>
         /// <param name="requestUrl">The HTTP request url.</param>
         /// <param name="content">The HTTP request message content.</param>
@@ -40,6 +54,21 @@ namespace DFC.TestAutomation.UI.Support
             this.Client = new HttpClient();
             var messageContent = GetHttpContentFromObject(content);
             this.RequestMessage = CreateRequestMessage(httpMethod, requestUrl, messageContent);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestSupport{T}"/> class.
+        /// </summary>
+        /// <param name="networkCredentials">The network credentials.</param>
+        /// <param name="httpMethod">The HTTP method.</param>
+        /// <param name="requestUrl">The HTTP request url.</param>
+        /// <param name="content">The HTTP request message content.</param>
+        public HttpRequestSupport(NetworkCredential networkCredentials, HttpMethod httpMethod, Uri requestUrl, T content)
+        {
+            this.Client = new HttpClient();
+            var messageContent = GetHttpContentFromObject(content);
+            this.RequestMessage = CreateRequestMessage(httpMethod, requestUrl, messageContent);
+            this.AddNetworkCredentials(networkCredentials);
         }
 
         /// <summary>
@@ -62,6 +91,31 @@ namespace DFC.TestAutomation.UI.Support
                     this.RequestMessage.Headers.Add(header.Key, header.Value);
                 }
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestSupport{T}"/> class.
+        /// </summary>
+        /// <param name="networkCredentials">The network credentials.</param>
+        /// <param name="httpMethod">The HTTP method.</param>
+        /// <param name="requestUrl">The HTTP request url.</param>
+        /// <param name="content">The HTTP message content.</param>
+        /// <param name="headers">The HTTP message headers.</param>
+        public HttpRequestSupport(NetworkCredential networkCredentials, HttpMethod httpMethod, Uri requestUrl, T content, IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            this.Client = new HttpClient();
+            var messageContent = GetHttpContentFromObject(content);
+            this.RequestMessage = CreateRequestMessage(httpMethod, requestUrl, messageContent);
+
+            if (headers != null)
+            {
+                foreach (var header in headers)
+                {
+                    this.RequestMessage.Headers.Add(header.Key, header.Value);
+                }
+            }
+
+            this.AddNetworkCredentials(networkCredentials);
         }
 
         private bool Disposed { get; set; }
@@ -127,6 +181,12 @@ namespace DFC.TestAutomation.UI.Support
                 messageContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
                 return messageContent;
             }
+        }
+
+        private void AddNetworkCredentials(NetworkCredential networkCredential)
+        {
+            var byteArray = Encoding.ASCII.GetBytes(networkCredential?.UserName + ":" + networkCredential?.Password);
+            this.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
         }
     }
 }

--- a/DFC.TestAutomation.UI/Support/HttpRequestSupport.cs
+++ b/DFC.TestAutomation.UI/Support/HttpRequestSupport.cs
@@ -178,7 +178,7 @@ namespace DFC.TestAutomation.UI.Support
             var jsonContent = JsonConvert.SerializeObject(content);
             var byteContent = Encoding.UTF8.GetBytes(jsonContent);
             this.MessageContent = new ByteArrayContent(byteContent);
-            this.MessageContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            this.MessageContent.Headers.ContentType = new MediaTypeWithQualityHeaderValue("application/json");
         }
 
         private void AddNetworkCredentials(NetworkCredential networkCredential)


### PR DESCRIPTION
This PR includes the following:

1. An update to the `BrowserStackHelper` class so we can now send a passed status and a failed status to the BrowserStack API.
2. Added a `BrowserStackTestStatus` model to help with submitting information to the BrowserStack API.
3. Fixed a dispose issue with the `HttpRequestSupport` class.
4. Added additional constructors for the `HttpRequestSupport` class so we can pass in `NetworkCredentials`.
