### PR TITLE
Story/DFCC-1418: Convert to XUnit

### DIFF
--- a/DFC.TestAutomation.UI.nuspec
+++ b/DFC.TestAutomation.UI.nuspec
@@ -19,15 +19,12 @@
         <dependency id="Microsoft.Extensions.Configuration.Binder" version="3.1.9" />
         <dependency id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="3.1.9" />
         <dependency id="Microsoft.Extensions.Configuration.Json" version="3.1.9" />
-        <dependency id="NUnit" version="3.12.0" />
         <dependency id="Polly" version="7.2.1" />
         <dependency id="RestSharp" version="106.11.7" />
-        <dependency id="Selenium.Axe" version="1.5.2" />
+        <dependency id="Selenium.Axe" version="2.0.0" />
         <dependency id="Selenium.Support" version="3.141.0" />
         <dependency id="Selenium.WebDriver" version="3.141.0" />
         <dependency id="Specflow" version="3.4.14" />
-        <dependency id="Specflow.nunit" version="3.4.14" />
-        <dependency id="Specflow.tools.msbuild.generation" version="3.4.14" />
       </group>
     </dependencies>
   </metadata>

--- a/DFC.TestAutomation.UI/DFC.TestAutomation.UI.csproj
+++ b/DFC.TestAutomation.UI/DFC.TestAutomation.UI.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="RestSharp" Version="106.11.7" />
-    <PackageReference Include="Selenium.Axe" Version="1.5.2" />
+    <PackageReference Include="Selenium.Axe" Version="2.0.0" />
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />

--- a/DFC.TestAutomation.UI/DFC.TestAutomation.UI.csproj
+++ b/DFC.TestAutomation.UI/DFC.TestAutomation.UI.csproj
@@ -34,7 +34,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="RestSharp" Version="106.11.7" />
     <PackageReference Include="Selenium.Axe" Version="1.5.2" />
@@ -43,8 +42,6 @@
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="86.0.4240.2200" />
     <PackageReference Include="SpecFlow" Version="3.4.14" />
-    <PackageReference Include="Specflow.nunit" Version="3.4.14" />
-    <PackageReference Include="Specflow.tools.msbuild.generation" Version="3.4.14" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.TestAutomation.UI/Helper/BrowserStackHelper.cs
+++ b/DFC.TestAutomation.UI/Helper/BrowserStackHelper.cs
@@ -6,7 +6,6 @@
 using DFC.TestAutomation.UI.Model;
 using DFC.TestAutomation.UI.Settings;
 using DFC.TestAutomation.UI.Support;
-using NUnit.Framework;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Edge;

--- a/DFC.TestAutomation.UI/Helper/RetryHelper.cs
+++ b/DFC.TestAutomation.UI/Helper/RetryHelper.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using DFC.TestAutomation.UI.Settings;
-using NUnit.Framework;
 using Polly;
 using System;
 using System.Collections.Generic;

--- a/DFC.TestAutomation.UI/Helper/ScreenshotHelper.cs
+++ b/DFC.TestAutomation.UI/Helper/ScreenshotHelper.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using NUnit.Framework;
 using OpenQA.Selenium;
 using System;
 using System.Globalization;
@@ -42,7 +41,6 @@ namespace DFC.TestAutomation.UI.Helper
             Screenshot screenshot = screenshotHandler.GetScreenshot();
             var screenshotPath = Path.Combine(this.FolderDirectory, screenshotName);
             screenshot.SaveAsFile(screenshotPath, ScreenshotImageFormat.Png);
-            TestContext.AddTestAttachment(screenshotPath, screenshotName);
         }
     }
 }


### PR DESCRIPTION
- Removed all references to NUnit.
- Removed the logic that saves the screenshot to the test context as an attachment. This is NUnit dependent and not required.
- Updated the Selenium Axe package.
- Removed unnecessary Specflow references.
- .nuspec file updated with the above.