### PR TITLE
Fix for a click failure on the contact us form

### DIFF
--- a/DFC.TestAutomation.UI.UnitTests/HelperTests/FormHelperTests.cs
+++ b/DFC.TestAutomation.UI.UnitTests/HelperTests/FormHelperTests.cs
@@ -25,15 +25,13 @@ namespace DFC.TestAutomation.UI.UnitTests.HelperTests
             this.WebElement = A.Fake<IWebElement>(x => x.Implements<ILocatable>());
             this.WebDriverWaitHelper = A.Fake<IWebDriverWaitHelper>();
             this.WebDriver = A.Fake<IWebDriver>(builder => builder.Implements(typeof(IHasInputDevices)).Implements(typeof(IActionExecutor)));
-
-            var action = A.Fake<IAction>();
             this.ActionsFactory = A.Fake<IActionsFactory>();
-            var test = A.Fake<Actions>((x) => x.WithArgumentsForConstructor(() => new Actions(this.WebDriver)).Implements<IAction>());
-            A.CallTo(() => action.Perform()).DoesNothing();
+            var actions = A.Fake<Actions>((x) => x.WithArgumentsForConstructor(() => new Actions(this.WebDriver)).Implements<IAction>());
 
-            A.CallTo(() => this.ActionsFactory.Create()).Returns(test);
+            A.CallTo(() => this.ActionsFactory.Create()).Returns(actions);
             A.CallTo(() => this.WebDriverWaitHelper.WaitForElementToBeClickable(A<IWebElement>._)).DoesNothing();
             A.CallTo(() => this.WebDriver.FindElement(A<By>._)).Returns(this.WebElement);
+
             this.FormHelper = new FormHelper(this.WebDriver, this.WebDriverWaitHelper, this.ActionsFactory);
         }
 

--- a/DFC.TestAutomation.UI.UnitTests/HelperTests/FormHelperTests.cs
+++ b/DFC.TestAutomation.UI.UnitTests/HelperTests/FormHelperTests.cs
@@ -22,11 +22,11 @@ namespace DFC.TestAutomation.UI.UnitTests.HelperTests
     {
         public FormHelperTests()
         {
-            this.WebElement = A.Fake<IWebElement>(x => x.Implements<ILocatable>());
+            this.WebElement = A.Fake<IWebElement>(options => options.Implements<ILocatable>());
             this.WebDriverWaitHelper = A.Fake<IWebDriverWaitHelper>();
-            this.WebDriver = A.Fake<IWebDriver>(builder => builder.Implements(typeof(IHasInputDevices)).Implements(typeof(IActionExecutor)));
+            this.WebDriver = A.Fake<IWebDriver>(options => options.Implements(typeof(IHasInputDevices)).Implements(typeof(IActionExecutor)));
             this.ActionsFactory = A.Fake<IActionsFactory>();
-            var actions = A.Fake<Actions>((x) => x.WithArgumentsForConstructor(() => new Actions(this.WebDriver)).Implements<IAction>());
+            var actions = A.Fake<Actions>(options => options.WithArgumentsForConstructor(() => new Actions(this.WebDriver)).Implements<IAction>());
 
             A.CallTo(() => this.ActionsFactory.Create()).Returns(actions);
             A.CallTo(() => this.WebDriverWaitHelper.WaitForElementToBeClickable(A<IWebElement>._)).DoesNothing();
@@ -138,7 +138,7 @@ namespace DFC.TestAutomation.UI.UnitTests.HelperTests
             A.CallTo(() => optionTwo.GetAttribute(A<string>._)).Returns("A different attribute value");
             A.CallTo(() => this.WebElement.TagName).Returns("select");
             A.CallTo(() => this.WebElement.FindElements(A<By>._)).Returns(new ReadOnlyCollection<IWebElement>(new List<IWebElement>() { optionOne, optionTwo }));
-            var selectElement = A.Fake<SelectElement>((fake) => fake.WithArgumentsForConstructor(() => new SelectElement(this.WebElement)));
+            var selectElement = A.Fake<SelectElement>(options => options.WithArgumentsForConstructor(() => new SelectElement(this.WebElement)));
 
             Assert.Throws<NotFoundException>(() => this.FormHelper.SelectByAttribute(selectElement, "attributeName", "attribute"));
         }
@@ -147,12 +147,12 @@ namespace DFC.TestAutomation.UI.UnitTests.HelperTests
         public void SelectByAttributeThrowsNotsFoundExceptionWhenNoOptionIsFound()
         {
             var optionOne = A.Fake<IWebElement>();
-            var optionTwo = A.Fake<IWebElement>(x => x.Implements<ILocatable>());
+            var optionTwo = A.Fake<IWebElement>(options => options.Implements<ILocatable>());
             A.CallTo(() => optionOne.GetAttribute(A<string>._)).Returns("A different attribute value");
             A.CallTo(() => optionTwo.GetAttribute(A<string>._)).Returns("attribute");
             A.CallTo(() => this.WebElement.TagName).Returns("select");
             A.CallTo(() => this.WebElement.FindElements(A<By>._)).Returns(new ReadOnlyCollection<IWebElement>(new List<IWebElement>() { optionOne, optionTwo }));
-            var selectElement = A.Fake<SelectElement>((fake) => fake.WithArgumentsForConstructor(() => new SelectElement(this.WebElement)));
+            var selectElement = A.Fake<SelectElement>(options => options.WithArgumentsForConstructor(() => new SelectElement(this.WebElement)));
             this.FormHelper.SelectByAttribute(selectElement, "attributeName", "attribute");
 
             A.CallTo(() => this.WebDriverWaitHelper.WaitForElementToBeClickable(optionTwo)).MustHaveHappenedOnceExactly();

--- a/DFC.TestAutomation.UI/Factory/ActionsFactory.cs
+++ b/DFC.TestAutomation.UI/Factory/ActionsFactory.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="ActionsFactory.cs" company="National Careers Service">
+// Copyright (c) National Careers Service. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
+
+namespace DFC.TestAutomation.UI.Factory
+{
+    public class ActionsFactory : IActionsFactory
+    {
+        public ActionsFactory(IWebDriver webDriver)
+        {
+            this.WebDriver = webDriver;
+        }
+
+        private IWebDriver WebDriver { get; set; }
+
+        /// <summary>
+        /// Creates a new instance of the Actions class.
+        /// </summary>
+        /// <returns>The Actions class.</returns>
+        public Actions Create()
+        {
+            return new Actions(this.WebDriver);
+        }
+    }
+}

--- a/DFC.TestAutomation.UI/Factory/IActionsFactory.cs
+++ b/DFC.TestAutomation.UI/Factory/IActionsFactory.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="IActionsFactory.cs" company="National Careers Service">
+// Copyright (c) National Careers Service. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using OpenQA.Selenium.Interactions;
+
+namespace DFC.TestAutomation.UI.Factory
+{
+    /// <summary>
+    /// An interface containing definitions for all Actions related operations.
+    /// </summary>
+    public interface IActionsFactory
+    {
+        /// <summary>
+        /// Creates a new instance of the Actions class.
+        /// </summary>
+        /// <returns>The Actions class.</returns>
+        Actions Create();
+    }
+}

--- a/DFC.TestAutomation.UI/Helper/FormHelper.cs
+++ b/DFC.TestAutomation.UI/Helper/FormHelper.cs
@@ -3,13 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using DFC.TestAutomation.UI.Factory;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Support.UI;
-using Polly;
 using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Globalization;
 using System.Linq;
 
@@ -25,15 +22,18 @@ namespace DFC.TestAutomation.UI.Helper
         /// </summary>
         /// <param name="webDriver">The Selenium Webdriver.</param>
         /// <param name="webDriverWaitHelper">The Selenium Webdriver wait helper.</param>
-        public FormHelper(IWebDriver webDriver, IWebDriverWaitHelper webDriverWaitHelper)
+        public FormHelper(IWebDriver webDriver, IWebDriverWaitHelper webDriverWaitHelper, IActionsFactory actionsFactory)
         {
             this.WebDriver = webDriver;
             this.WebDriverWaitHelper = webDriverWaitHelper;
+            this.ActionsFactory = actionsFactory;
         }
 
         private IWebDriver WebDriver { get; set; }
 
         private IWebDriverWaitHelper WebDriverWaitHelper { get; set; }
+
+        private IActionsFactory ActionsFactory { get; set; }
 
         /// <summary>
         /// Selects a radio button using an IWebElement. If the radio button is already selected, then it will remain selected.
@@ -47,7 +47,7 @@ namespace DFC.TestAutomation.UI.Helper
             }
 
             this.WebDriverWaitHelper.WaitForElementToBeClickable(radioButtonElement);
-            radioButtonElement.Click();
+            this.ActionsFactory.Create().MoveToElement(radioButtonElement).Click().Perform();
         }
 
         /// <summary>
@@ -214,7 +214,7 @@ namespace DFC.TestAutomation.UI.Helper
                 if (!checkboxElement.Selected)
                 {
                     this.WebDriverWaitHelper.WaitForElementToBeClickable(checkboxElement);
-                    checkboxElement.Click();
+                    this.ActionsFactory.Create().MoveToElement(checkboxElement).Click().Perform();
                 }
             }
         }
@@ -237,7 +237,7 @@ namespace DFC.TestAutomation.UI.Helper
             if (selectOption != null)
             {
                 this.WebDriverWaitHelper.WaitForElementToBeClickable(selectOption);
-                selectOption.Click();
+                this.ActionsFactory.Create().MoveToElement(selectOption).Click().Perform();
             }
             else
             {

--- a/DFC.TestAutomation.UI/Helper/HelperLibrary.cs
+++ b/DFC.TestAutomation.UI/Helper/HelperLibrary.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using DFC.TestAutomation.UI.Factory;
 using DFC.TestAutomation.UI.Settings;
 using OpenQA.Selenium;
 
@@ -26,7 +27,7 @@ namespace DFC.TestAutomation.UI.Helper
             this.RetryHelper = new RetryHelper(settingsLibrary.TestExecutionSettings.RetrySettings);
             this.AxeHelper = new AxeHelper(webDriver);
             this.BrowserHelper = new BrowserHelper(settingsLibrary?.BrowserSettings.BrowserName);
-            this.FormHelper = new FormHelper(webDriver, this.WebDriverWaitHelper);
+            this.FormHelper = new FormHelper(webDriver, this.WebDriverWaitHelper, new ActionsFactory(webDriver));
             this.CommonActionHelper = new CommonActionHelper(webDriver, this.WebDriverWaitHelper, this.RetryHelper);
             this.ScreenshotHelper = new ScreenshotHelper(webDriver);
             this.BrowserStackHelper = new BrowserStackHelper<T>(settingsLibrary.BrowserStackSettings);


### PR DESCRIPTION
- Changed the way we click in a form. We now use the Actions class which does not interrogate the web element before clicking it. It is a more basic approach but better suited for our use.
- Added an Actions factory to facilitate unit testing.
- Updated the unit tests.